### PR TITLE
Add sveltekit-mdsvex-blog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,8 @@ Please note that we recommend adders instead of templates in most cases. Adders 
   - SvelteKit boilerplate with Koa for building backend API, Typescript support, Docker support
 - [SvelteKit Stripe](https://github.com/srmullen/sveltekit-stripe)
   - SvelteKit template with Stripe Checkout and Typescript.
+- [SvelteKit MDsveX Blog](https://github.com/mvasigh/sveltekit-mdsvex-blog)
+  - A minimalistic blog template built with SvelteKit and MDsveX
 
 ### Sapper
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

**[SvelteKit MDsveX Blog](https://github.com/mvasigh/sveltekit-mdsvex-blog)**
**A minimalistic blog template built with SvelteKit and MDsveX. It is a simple example of how to use MDsveX and SvelteKit to produce a static blog site, including using frontmatter from posts in other pages.**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.